### PR TITLE
Update flagshipshipping.php

### DIFF
--- a/flagshipshipping.php
+++ b/flagshipshipping.php
@@ -472,7 +472,7 @@ class FlagshipShipping extends CarrierModule
 
         $options = [
             "signature_required"=>false,
-            "reference"=>substr("PrestaShop Order# ".$orderId,0,29),
+            "reference"=>substr(Configuration::get('PS_SHOP_NAME')." Order# ".$orderId,0,29),
             "driver_instructions"=>substr($driverInstructions,0,29),
             "shipment_tracking_emails"=> $trackingEmail
         ];


### PR DESCRIPTION
Change reference from 'reference' => 'PrestaShop Order# ' . $order_id, to "reference"=>substr(Configuration::get('PS_SHOP_NAME')." Order# ".$orderId,0,29),


This is preferred for my shop to show on the tracking emails that it is from my shop not just "Prestashop".